### PR TITLE
Align menus across pages

### DIFF
--- a/plataforma.html
+++ b/plataforma.html
@@ -43,10 +43,11 @@
       </a>
     </div>
     <nav aria-label="Menú principal">
-      <a href="index.html#como-funciona">Cómo funciona</a>
+      <a href="como-funciona.html">Cómo funciona</a>
       <a href="index.html#proyectos">Proyectos</a>
-      <a href="index.html#calculadora">Calculadora</a>
+      <a href="simulador.html">Simulador</a>
       <a href="plataforma.html" class="active">Plataforma</a>
+      <a href="certificados.html">Certificados</a>
       <a href="index.html#contacto">Contacto</a>
     </nav>
   </header>
@@ -258,9 +259,11 @@
       <p>&copy; 2025 ConTuCuota &middot; <a href="mailto:info@contucuota.es">info@contucuota.es</a></p>
       <div class="footer-links">
         <a href="index.html">Inicio</a>
-        <a href="index.html#como-funciona">Cómo funciona</a>
+        <a href="como-funciona.html">Cómo funciona</a>
         <a href="index.html#proyectos">Proyectos</a>
+        <a href="simulador.html">Simulador</a>
         <a href="plataforma.html">Plataforma</a>
+        <a href="certificados.html">Certificados</a>
         <a href="index.html#contacto">Contacto</a>
       </div>
       <small>Plataforma en fase de desarrollo. La disponibilidad de funciones puede variar.</small>

--- a/simulador.html
+++ b/simulador.html
@@ -43,10 +43,11 @@
       </a>
     </div>
     <nav aria-label="Menú principal">
-      <a href="index.html#como-funciona">Cómo funciona</a>
+      <a href="como-funciona.html">Cómo funciona</a>
       <a href="index.html#proyectos">Proyectos</a>
       <a href="simulador.html" class="active">Simulador</a>
       <a href="plataforma.html">Plataforma</a>
+      <a href="certificados.html">Certificados</a>
       <a href="index.html#contacto">Contacto</a>
     </nav>
   </header>
@@ -317,10 +318,11 @@
       <p>&copy; 2025 ConTuCuota &middot; <a href="mailto:info@contucuota.es">info@contucuota.es</a></p>
       <div class="footer-links">
         <a href="index.html">Inicio</a>
-        <a href="index.html#como-funciona">Cómo funciona</a>
+        <a href="como-funciona.html">Cómo funciona</a>
         <a href="index.html#proyectos">Proyectos</a>
         <a href="simulador.html">Simulador</a>
         <a href="plataforma.html">Plataforma</a>
+        <a href="certificados.html">Certificados</a>
         <a href="index.html#contacto">Contacto</a>
       </div>
       <small>Simulaciones orientativas. Consulta con tu asesor fiscal. Las deducciones pueden variar según el art. 68.1 LIRPF.</small>


### PR DESCRIPTION
## Summary
- sync navigation menus on **simulador.html** and **plataforma.html** with the main page
- include links to `como-funciona.html` and `certificados.html` in nav and footer

## Testing
- `npm test` *(fails: jest not found)*