### PR TITLE
Adjust capital recovery timing

### DIFF
--- a/simulador.html
+++ b/simulador.html
@@ -63,7 +63,7 @@
       <div class="container">
         <h2 class="section-title">Simulador de Inversión Recurrente</h2>
         <p class="section-text">
-          Selecciona el ticket anual y años de inversión para visualizar los flujos financieros. Se deduce el 50% al año siguiente y se recupera el 50% del capital desde el año 4 mediante recompra pactada.
+          Selecciona el ticket anual y años de inversión para visualizar los flujos financieros. Se deduce el 50% al año siguiente y se recupera el 50% del capital tres años después de cada aportación (desde el año 4) mediante recompra pactada.
         </p>
         <div class="simulator-container">
           <div class="simulator-controls">
@@ -172,7 +172,7 @@
           
           <div id="explicacionSim" class="simulator-explanation">
             <p><strong>Interpretación:</strong></p>
-            <p>La barra roja representa el dinero aportado (flujo negativo), la verde la deducción fiscal recuperada al año siguiente, y la azul el capital recuperado a partir del año 4.</p>
+            <p>La barra roja representa el dinero aportado (flujo negativo), la verde la deducción fiscal recuperada al año siguiente, y la azul el capital recuperado tres años después de cada aportación.</p>
             <p>La línea punteada rosa muestra el capital que permanece en la empresa en cada momento.</p>
           </div>
           

--- a/simulador.js
+++ b/simulador.js
@@ -5,7 +5,8 @@
  * considerando:
  * - Aportaciones anuales desde el año 1 al año 5 (configurable)
  * - Deducción fiscal del 50% al año siguiente de cada aportación
- * - Recuperación del 50% del capital aportado a partir del final del año 4
+ * - Recuperación del 50% del capital aportado tres años después de cada aportación
+ *   (por defecto comienza a recuperarse al final del año 4)
  * - Módulo específico para simular diferentes escenarios para el capital remanente
  */
 
@@ -35,7 +36,7 @@ function simularInversionBasica() {
   const parametrosBase = {
     tasaDeduccion: 0.5,                // 50% de deducción fiscal
     tasaRecuperacionCapital: 0.5,      // 50% de recuperación del capital
-    inicioRecuperacion: 4,             // Año de inicio de recuperación (año 4)
+    inicioRecuperacion: 3,             // Desfase de recuperación en años (3 → comienza en el año 4)
     duracionRecuperacion: 1,           // Duración de la recuperación (1 año)
     tasaDescuento: 0.03,               // Tasa de descuento para VAN (3%)
     inflacionAnual: 0.02               // Inflación anual estimada (2%)
@@ -80,7 +81,8 @@ function calcularFlujosPrincipales(ticketAnual, aniosInversion, parametros) {
     }
   }
   
-  // 3. Calcular recuperaciones de capital (50% del capital aportado, a partir del año 4)
+  // 3. Calcular recuperaciones de capital
+  //    (50% del capital aportado tres años después de cada contribución)
   for (let i = 0; i < aniosInversion; i++) {
     const anioRecuperacion = i + parametros.inicioRecuperacion;
     if (anioRecuperacion < 10) {

--- a/tests/simulador.test.js
+++ b/tests/simulador.test.js
@@ -5,7 +5,7 @@ describe('calcularFlujosPrincipales', () => {
     const params = {
       tasaDeduccion: 0.5,
       tasaRecuperacionCapital: 0.5,
-      inicioRecuperacion: 4
+      inicioRecuperacion: 3
     };
     const result = calcularFlujosPrincipales(1000, 3, params);
 
@@ -20,24 +20,24 @@ describe('calcularFlujosPrincipales', () => {
       0, 0, 0, 0, 0
     ]);
     expect(result.recuperacionCapital).toEqual([
-      0, 0, 0, 0, 500,
-      500, 500, 0, 0, 0
+      0, 0, 0, 500, 500,
+      500, 0, 0, 0, 0
     ]);
     expect(result.flujoNetoAnual).toEqual([
       -1000, -500, -500,
-      500, 500, 500,
-      500, 0, 0,
+      1000, 500, 500,
+      0, 0, 0,
       0
     ]);
     expect(result.flujoAcumulado).toEqual([
       -1000, -1500, -2000,
-      -1500, -1000, -500,
+      -1000, -500, 0,
       0, 0, 0,
       0
     ]);
     expect(result.capitalEnEmpresa).toEqual([
       1000, 2000, 3000,
-      3000, 2500, 2000,
+      2500, 2000, 1500,
       1500, 1500, 1500,
       1500
     ]);


### PR DESCRIPTION
## Summary
- shift capital recovery to occur three years after each contribution
- update explanatory comments in the simulator
- expect earlier recoveries in unit tests
- clarify simulator HTML text about recovery timing

## Testing
- `npm test` *(fails: jest not found)*