### PR TITLE
Implement PDF generation service

### DIFF
--- a/certificados.css
+++ b/certificados.css
@@ -155,6 +155,16 @@
   margin-top: 2rem;
 }
 
+.download-hint {
+  margin-top: 1rem;
+  font-size: var(--font-size-sm);
+  color: var(--text-color);
+}
+
+.hidden {
+  display: none !important;
+}
+
 .prev-button,
 .next-button {
   padding: 0.8rem 1.5rem;

--- a/certificados.html
+++ b/certificados.html
@@ -436,6 +436,10 @@
                 <button type="button" class="prev-button" onclick="prevStep(5)">Anterior</button>
                 <button type="button" class="generate-button" onclick="generarCertificado()">Generar certificado</button>
               </div>
+              <p id="descarga-indicaciones" class="download-hint hidden">
+                El certificado se descargará automáticamente. Si no comienza la descarga,
+                <a id="enlace-descarga" href="#">haz clic aquí</a>.
+              </p>
             </div>
           </div>
         </div>

--- a/certificados.js
+++ b/certificados.js
@@ -375,15 +375,39 @@ function generarCertificado() {
     formato: document.getElementById('certificado-formato')?.value || '',
     firma: document.getElementById('certificado-firma')?.value || ''
   };
-  
-  // Aquí iría la lógica para generar el PDF
-  // Por ahora, mostraremos un mensaje de éxito
-  alert('Certificado generado correctamente. En una implementación real, aquí se generaría el PDF y se ofrecería para descarga.');
-  
-  // En una implementación real, aquí se llamaría a una función para generar el PDF
-  // usando una biblioteca como jsPDF o se enviarían los datos al servidor
-  
-  console.log('Datos del certificado:', window.certificadoData);
+
+  // Enviar los datos al servicio de generación de PDF
+  fetch('/api/certificado', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(window.certificadoData)
+  })
+    .then(response => {
+      if (!response.ok) throw new Error('Error en la generación');
+      return response.blob();
+    })
+    .then(blob => {
+      const url = window.URL.createObjectURL(blob);
+      const link = document.getElementById('enlace-descarga');
+      if (link) {
+        link.href = url;
+        link.download = 'certificado.pdf';
+      }
+      document.getElementById('descarga-indicaciones')?.classList.remove('hidden');
+
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'certificado.pdf';
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+    })
+    .catch(error => {
+      alert('Error al generar el certificado.');
+      console.error(error);
+    });
 }
 
 // Función auxiliar para formatear fechas

--- a/package.json
+++ b/package.json
@@ -2,9 +2,14 @@
   "name": "contucuota",
   "version": "1.0.0",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "start": "node server.js"
   },
   "devDependencies": {
     "jest": "^29.7.0"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "jspdf": "^2.5.1"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,42 @@
+const express = require('express');
+const { jsPDF } = require('jspdf');
+
+const app = express();
+app.use(express.json({ limit: '1mb' }));
+
+app.post('/api/certificado', (req, res) => {
+  const data = req.body || {};
+  try {
+    const doc = new jsPDF();
+
+    doc.text('Certificado de Inversión', 10, 10);
+
+    if (data.empresa) {
+      doc.text(`Empresa: ${data.empresa.nombre || ''}`, 10, 20);
+      doc.text(`CIF: ${data.empresa.cif || ''}`, 10, 30);
+    }
+
+    if (data.inversor) {
+      doc.text(`Inversor: ${data.inversor.nombre || ''}`, 10, 40);
+      doc.text(`NIF: ${data.inversor.nif || ''}`, 10, 50);
+    }
+
+    if (data.inversion) {
+      doc.text(`Fecha inversión: ${data.inversion.fecha || ''}`, 10, 60);
+      doc.text(`Importe: ${data.inversion.importe || ''}`, 10, 70);
+    }
+
+    const pdf = doc.output();
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', 'attachment; filename="certificado.pdf"');
+    return res.send(Buffer.from(pdf, 'binary'));
+  } catch (e) {
+    console.error('PDF generation error', e);
+    return res.status(500).json({ error: 'Error generando el certificado' });
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Certificado service listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add Express and jsPDF dependencies and start script
- create Node server for generating PDFs
- connect wizard to service using fetch
- show download instructions in the certificate form
- style download hint

## Testing
- `npm test` *(fails: jest not found)*