### PR TITLE
Add Jest tests for Payback and VAN

### DIFF
--- a/simulador.js
+++ b/simulador.js
@@ -761,6 +761,8 @@ if (typeof document !== 'undefined') {
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = {
     calcularFlujosPrincipales,
-    calcularTIR
+    calcularTIR,
+    calcularPayback,
+    calcularVAN
   };
 }

--- a/tests/paybackVan.test.js
+++ b/tests/paybackVan.test.js
@@ -1,0 +1,22 @@
+const { calcularPayback, calcularVAN } = require('../simulador');
+
+describe('calcularPayback', () => {
+  test('returns fractional year when recovery occurs between periods', () => {
+    const acumulados = [-1000, -400, 200];
+    const payback = calcularPayback(acumulados);
+    expect(payback).toBeCloseTo(2.6667, 4);
+  });
+
+  test('returns horizon length + 1 when never recovered', () => {
+    const acumulados = [-500, -300, -100];
+    const payback = calcularPayback(acumulados);
+    expect(payback).toBe(acumulados.length + 1);
+  });
+});
+
+describe('calcularVAN', () => {
+  test('computes net present value for simple flows', () => {
+    const van = calcularVAN([-1000, 600, 600], 0.1);
+    expect(van).toBeCloseTo(37.5657, 4);
+  });
+});


### PR DESCRIPTION
## Summary
- export `calcularPayback` and `calcularVAN` from the simulator for Node tests
- add new Jest tests for `calcularPayback` and `calcularVAN`

## Testing
- `npm test` *(fails: jest not found)*