### PR TITLE
Add certificado API tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "node server.js"
   },
   "devDependencies": {
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   },
   "dependencies": {
     "express": "^4.18.2",

--- a/server.js
+++ b/server.js
@@ -37,6 +37,10 @@ app.post('/api/certificado', (req, res) => {
 });
 
 const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-  console.log(`Certificado service listening on port ${PORT}`);
-});
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Certificado service listening on port ${PORT}`);
+  });
+}
+
+module.exports = app;

--- a/tests/certificado.test.js
+++ b/tests/certificado.test.js
@@ -1,0 +1,29 @@
+const request = require('supertest');
+const app = require('../server');
+
+describe('POST /api/certificado', () => {
+  test('returns PDF for valid input', async () => {
+    const data = {
+      empresa: { nombre: 'ACME', cif: 'A1' },
+      inversor: { nombre: 'Investor', nif: 'N1' },
+      inversion: { fecha: '2023-01-01', importe: 1000 }
+    };
+
+    const res = await request(app)
+      .post('/api/certificado')
+      .send(data);
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/application\/pdf/);
+    expect(res.body.length).toBeGreaterThan(0);
+  });
+
+  test('returns 400 for malformed JSON', async () => {
+    const res = await request(app)
+      .post('/api/certificado')
+      .set('Content-Type', 'application/json')
+      .send('{"badJson":');
+
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- export Express app from `server.js` so it can be tested
- add `supertest` as a development dependency
- create API tests for `/api/certificado`

## Testing
- `npm test` *(fails: jest: not found)*