### PR TITLE
Add security headers and HTTPS redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ El proyecto cuenta con pruebas autom\u00e1ticas ubicadas en la carpeta
 npm test
 ```
 
+## Variables de entorno
+
+La API que genera certificados lee las siguientes variables de entorno:
+
+- `PORT`: puerto en el que se inicia el servidor (por defecto `3000`).
+- `NODE_ENV`: si vale `production` se redirigen las peticiones HTTP a HTTPS.
+
 ## C\u00f3mo contribuir
 
 1. Haz un *fork* de este repositorio y cl\u00f3nalo en tu equipo.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "express": "^4.18.2",
-    "jspdf": "^2.5.1"
+    "jspdf": "^2.5.1",
+    "helmet": "^7.0.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,8 +1,21 @@
 const express = require('express');
+const helmet = require('helmet');
 const { jsPDF } = require('jspdf');
 
 const app = express();
+app.use(helmet());
 app.use(express.json({ limit: '1mb' }));
+
+if (process.env.NODE_ENV === 'production') {
+  app.enable('trust proxy');
+  app.use((req, res, next) => {
+    const isHttps = req.secure || req.get('x-forwarded-proto') === 'https';
+    if (!isHttps) {
+      return res.redirect('https://' + req.headers.host + req.originalUrl);
+    }
+    next();
+  });
+}
 
 app.post('/api/certificado', (req, res) => {
   const data = req.body || {};


### PR DESCRIPTION
## Summary
- add helmet dependency
- secure Express server with helmet and optional HTTPS redirect in production
- document PORT and NODE_ENV environment variables

## Testing
- `npm test` *(fails: jest not found)*