### PR TITLE
Fix certificados nav

### DIFF
--- a/certificados.html
+++ b/certificados.html
@@ -32,6 +32,7 @@
   <link rel="stylesheet" href="https://unpkg.com/aos@2.3.1/dist/aos.css" />
   <!-- Carga diferida de scripts no críticos -->
   <script defer src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+  <script defer src="./menu.js"></script>
   <script defer src="./certificados.js"></script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add the menu script to `certificados.html` so the navigation menu works like on other pages

## Testing
- `npm test` *(fails: jest not found)*