### PR TITLE
Add note about installing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ framework de pruebas `jest`.
 ## Ejecuci\u00f3n de pruebas
 
 El proyecto cuenta con pruebas autom\u00e1ticas ubicadas en la carpeta
-`tests`. Para ejecutarlas utiliza el siguiente comando:
-
+`tests`. Antes de ejecutarlas asegúrate de instalar las dependencias con `npm install` — durante el desarrollo se utilizó Node.js 18. Luego utiliza el siguiente comando:
 ```bash
 npm test
 ```


### PR DESCRIPTION
## Summary
- remind users to run `npm install` before executing tests
- mention Node 18 was used during development

## Testing
- `npm test` *(fails: jest not found)*