### PR TITLE
Add Express backend with Prisma and auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,12 @@ pm2 start server.js --name contucuota
 docker build -t contucuota .
 docker run -p 3000:3000 --env PORT=3000 contucuota
 ```
+\n## Backend API
+
+El directorio `backend/` incluye un servidor Express con Prisma y
+autenticaci\u00f3n JWT. Proporciona endpoints REST para la gesti\u00f3n de
+usuarios, inversores, proyectos y la generaci\u00f3n de certificados en
+PDF.
+
+Consulta `backend/README.md` para conocer las variables de entorno
+necesarias, pasos de despliegue y comandos de desarrollo.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,8 @@
+# URL de la base de datos PostgreSQL
+DATABASE_URL=postgresql://user:password@localhost:5432/contucuota
+
+# Clave para firmar tokens JWT
+JWT_SECRET=cambia_esta_clave
+
+# Puerto de escucha del servidor
+PORT=4000

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,44 @@
+# ConTuCuota Backend
+
+Este directorio contiene una API REST escrita con Express y Prisma que
+proporciona funcionalidad para la gesti\u00f3n de usuarios, inversores,
+proyectos y generaci\u00f3n de certificados en PDF.
+
+## Variables de entorno
+
+- `DATABASE_URL`: cadena de conexi\u00f3n a PostgreSQL (por ejemplo,
+  `postgresql://user:password@localhost:5432/contucuota`).
+- `JWT_SECRET`: clave utilizada para firmar los tokens JWT.
+- `PORT`: puerto en el que se iniciar\u00e1 el servidor (por defecto 4000).
+
+Copia el archivo `.env.example` a `.env` y ajusta estos valores antes de
+iniciar la aplicaci\u00f3n.
+
+## Puesta en marcha
+
+1. Instala las dependencias:
+
+   ```bash
+   npm install
+   ```
+
+2. Inicializa la base de datos y genera el cliente Prisma:
+
+   ```bash
+   npx prisma migrate deploy
+   ```
+
+3. Inicia el servidor:
+
+   ```bash
+   npm run dev
+   ```
+
+La API quedar\u00e1 disponible en `http://localhost:4000/`.
+
+## Despliegue
+
+En producci\u00f3n se recomienda emplear un gestor de procesos como `pm2` o
+contenizar el servidor con Docker. Aseg\u00farate de establecer las
+variables de entorno y de ejecutar `prisma migrate deploy` contra la
+base de datos de producci\u00f3n.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "contucuota-backend",
+  "version": "1.0.0",
+  "main": "src/server.js",
+  "scripts": {
+    "dev": "node src/server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "@prisma/client": "^5.7.0",
+    "bcrypt": "^5.1.0",
+    "jsonwebtoken": "^9.0.0",
+    "jspdf": "^2.5.1"
+  },
+  "devDependencies": {
+    "prisma": "^5.7.0"
+  }
+}

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,0 +1,36 @@
+// Prisma schema for ConTuCuota backend
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  password  String
+  createdAt DateTime @default(now())
+}
+
+model Investor {
+  id        Int      @id @default(autoincrement())
+  nombre    String
+  email     String
+  telefono  String
+  projects  Project[]
+  createdAt DateTime @default(now())
+}
+
+model Project {
+  id               Int      @id @default(autoincrement())
+  nombre_proyecto  String
+  email_proyecto   String
+  telefono_proyecto String
+  investorId       Int?
+  investor         Investor? @relation(fields: [investorId], references: [id])
+  createdAt        DateTime  @default(now())
+}

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,0 +1,122 @@
+const express = require('express');
+const { PrismaClient } = require('@prisma/client');
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+const { jsPDF } = require('jspdf');
+
+const prisma = new PrismaClient();
+const app = express();
+app.use(express.json({ limit: '1mb' }));
+
+const JWT_SECRET = process.env.JWT_SECRET || 'change_this';
+
+function createToken(user) {
+  return jwt.sign({ userId: user.id }, JWT_SECRET, { expiresIn: '7d' });
+}
+
+app.post('/auth/register', async (req, res) => {
+  const { email, password } = req.body || {};
+  if (!email || !password) {
+    return res.status(400).json({ error: 'email and password required' });
+  }
+  const hashed = await bcrypt.hash(password, 10);
+  try {
+    const user = await prisma.user.create({ data: { email, password: hashed } });
+    const token = createToken(user);
+    return res.status(201).json({ token });
+  } catch (e) {
+    return res.status(400).json({ error: 'user already exists' });
+  }
+});
+
+app.post('/auth/login', async (req, res) => {
+  const { email, password } = req.body || {};
+  if (!email || !password) {
+    return res.status(400).json({ error: 'email and password required' });
+  }
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (!user) return res.status(401).json({ error: 'invalid credentials' });
+  const valid = await bcrypt.compare(password, user.password);
+  if (!valid) return res.status(401).json({ error: 'invalid credentials' });
+  const token = createToken(user);
+  return res.json({ token });
+});
+
+function auth(req, res, next) {
+  const header = req.headers['authorization'];
+  if (!header) return res.status(401).json({ error: 'missing auth header' });
+  const token = header.split(' ')[1];
+  try {
+    const payload = jwt.verify(token, JWT_SECRET);
+    req.userId = payload.userId;
+    next();
+  } catch (e) {
+    return res.status(401).json({ error: 'invalid token' });
+  }
+}
+
+app.post('/investors', auth, async (req, res) => {
+  const { nombre, email, telefono } = req.body || {};
+  if (!nombre || !email || !telefono) {
+    return res.status(400).json({ error: 'missing fields' });
+  }
+  const investor = await prisma.investor.create({ data: { nombre, email, telefono } });
+  res.status(201).json(investor);
+});
+
+app.get('/investors', auth, async (req, res) => {
+  const investors = await prisma.investor.findMany();
+  res.json(investors);
+});
+
+app.post('/projects', auth, async (req, res) => {
+  const { nombre_proyecto, email_proyecto, telefono_proyecto, investorId } = req.body || {};
+  if (!nombre_proyecto || !email_proyecto || !telefono_proyecto) {
+    return res.status(400).json({ error: 'missing fields' });
+  }
+  const project = await prisma.project.create({
+    data: { nombre_proyecto, email_proyecto, telefono_proyecto, investorId }
+  });
+  res.status(201).json(project);
+});
+
+app.get('/projects', auth, async (req, res) => {
+  const projects = await prisma.project.findMany();
+  res.json(projects);
+});
+
+app.post('/certificates', auth, async (req, res) => {
+  const data = req.body || {};
+  try {
+    const doc = new jsPDF();
+    doc.text('Certificado de Inversi\u00f3n', 10, 10);
+    if (data.empresa) {
+      doc.text(`Empresa: ${data.empresa.nombre || ''}`, 10, 20);
+      doc.text(`CIF: ${data.empresa.cif || ''}`, 10, 30);
+    }
+    if (data.inversor) {
+      doc.text(`Inversor: ${data.inversor.nombre || ''}`, 10, 40);
+      doc.text(`NIF: ${data.inversor.nif || ''}`, 10, 50);
+    }
+    if (data.inversion) {
+      doc.text(`Fecha inversi\u00f3n: ${data.inversion.fecha || ''}`, 10, 60);
+      doc.text(`Importe: ${data.inversion.importe || ''}`, 10, 70);
+    }
+    const pdf = doc.output();
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', 'attachment; filename="certificado.pdf"');
+    return res.send(Buffer.from(pdf, 'binary'));
+  } catch (e) {
+    console.error('PDF generation error', e);
+    return res.status(500).json({ error: 'error generating certificate' });
+  }
+});
+
+const PORT = process.env.PORT || 4000;
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`API listening on port ${PORT}`);
+  });
+}
+
+module.exports = app;


### PR DESCRIPTION
## Summary
- scaffold an Express backend under `backend/`
- use Prisma with PostgreSQL and JWT auth
- expose REST endpoints for investors, projects and certificates
- document environment variables, usage and deployment steps
- mention new backend in main README

## Testing
- `npm test` *(fails: jest not found)*